### PR TITLE
Better api/dbconnector.php. Fix #99.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.swp
 .idea/
+api/dbconnector.php
 assets/downloads/
 bbs/attachment/
 bbs/images/

--- a/api/dbconnector.sample.php
+++ b/api/dbconnector.sample.php
@@ -1,6 +1,6 @@
 <?php
 function dbconnect() {
-    $con = @mysql_connect('localhost','root','19951025')
+    $con = @mysql_connect('<dbserver>','<username>','<password>')
         or die("Cannot connect to database !!!");
     mysql_query("SET NAMES 'UTF8'");
 }


### PR DESCRIPTION
- Raname to api/dbconnector.sample.php.
- Add api/dbconnector.php to .gitignore.