### PR TITLE
change to absolute path

### DIFF
--- a/assets/api/securimage/securimage.php
+++ b/assets/api/securimage/securimage.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once '../../../config.php';
+require_once $_SERVER['DOCUMENT_ROOT']."/config.php";
 
 // error_reporting(E_ALL); ini_set('display_errors', 1); // uncomment this line for debugging
 error_reporting(E_ALL & ~E_NOTICE);


### PR DESCRIPTION
注册验证码和首页登录这两个php不在同一级目录，所以用相对路径总会有一个出错；干脆用绝对路径