### PR TITLE
fix homepage calendar mislocation

### DIFF
--- a/assets/css/eventCalendar_theme_responsive.css
+++ b/assets/css/eventCalendar_theme_responsive.css
@@ -101,7 +101,7 @@
 			}
 				.eventsCalendar-daysList.showAsWeek li.empty {
 					background-color: #ccc;
-					min-height:29px;
+					min-height:28px;
 				}
 			.eventsCalendar-day a {
 				text-decoration:none;


### PR DESCRIPTION
解决论坛首页日历错位的bug：1号之前的灰色占位li的高度大于1号日期li，所以灰色占位li挡住了第二行日期li的布局

![image](https://user-images.githubusercontent.com/62087098/96595944-c4678f80-131e-11eb-970e-3332c878e5d6.png)
