### PR TITLE
fix bug of bbs content paging

### DIFF
--- a/bbs/content/index.php
+++ b/bbs/content/index.php
@@ -389,7 +389,7 @@ for($i=0;$i<count(@$data);$i++){
 			<div class="pagecontrol">
 
 <?php
-$pages= ceil(intval($tdata['reply'])/12);
+$pages= ceil(intval($tdata['reply']+1)/12);
 @$page= intval($_GET['p']);
 if($page<1) $page=1;
 

--- a/bbs/index/index.php
+++ b/bbs/index/index.php
@@ -102,7 +102,7 @@ if ($username!="") {
 			$bid=$hot['bid'];
 			$tid=$hot['tid'];
 			$num=intval($hot['reply'])+1;
-			$page=ceil(($num-1)/12);
+			$page=ceil(($num)/12);
 			$link="../content?bid=$bid&tid=$tid&p=$page#$num";
 			if ($num==1) $author=$hot['author'];
 			else $author=$hot['replyer'];


### PR DESCRIPTION
修复两个和论坛页码计算有关的问题，当某个帖子有12k+1楼时：
 + 从bbs/index通过“论坛热点”进入帖子时，会错误地跳转到p=k页（而不是p=k+1页）
 + 帖子上方的翻页列表和下方的翻页列表页数不一致（下方比上方少一页）