### PR TITLE
将mysql查询字符集修改为utf8mb4以支持emoji

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -9,8 +9,8 @@ function dbconnect() {
     $con = @mysql_connect(CAPUBBS_DB_HOSTNAME, CAPUBBS_DB_USERNAME,
         CAPUBBS_DB_PASSWORD) or die("Cannot connect to database !!!");
 
-	// Need to change to `utf8mb4` in order to support emoji
-	mysql_query("SET NAMES 'UTF8'");
+    // Set to `utf8mb4` in order to support emoji
+	mysql_query("SET NAMES 'utf8mb4'");
 
 	// Allow insert null while the column is defined with not null
     mysql_query("SET sql_mode = ''");


### PR DESCRIPTION
将mysql查询使用的字符集修改为`utf8mb4`以支持emoji
需先在服务器修改数据库编码格式，详见[教程](https://www.jianshu.com/p/8780c1fd3940)