### PR TITLE
修复content页面标题显示很多Re:的问题

### DIFF
--- a/api/jiekouapi.php
+++ b/api/jiekouapi.php
@@ -850,8 +850,7 @@
                 echo "<capu><info><code>3</code><msg>帖子已锁定。</msg></info></capu>";exit;
             }
 
-            if (mb_strlen($text,'utf-8')>=143) $text=mb_substr($text,0,140,'utf-8')."...";
-            #if (strlen($text,'utf-8')>=320) $text=mb_substr($text,0,160,'utf-8')."...";
+            if (mb_strlen($text,'utf-8')>=503) $text=mb_substr($text,0,500,'utf-8')."...";
 
             $text_mysql_escaped=mysql_real_escape_string($text);
 

--- a/bbs/content/index.php
+++ b/bbs/content/index.php
@@ -32,7 +32,7 @@
 			$bdata=$dt;
 	}
 
-	$title=count($data)>0?$data[0]['title']:"没有这个帖子= =";
+	$title=count($data)>0?$tdata['title']:"没有这个帖子= =";
 	$lztitle="";if($see_lz!="") $lztitle="（只看楼主）&nbsp;&nbsp;";
 	function generateattach($name,$size,$price,$auth,$id,$free,$count){
 		$extension=substr($name, strrpos($name, ".")+1);


### PR DESCRIPTION
content页面标题数据来源从posts表改为threads表，解决了标题中有很多"Re: "及标题和版面首页显示不一致的问题